### PR TITLE
Optimize API usage

### DIFF
--- a/decrypter.go
+++ b/decrypter.go
@@ -40,11 +40,18 @@ func NewDecrypter(ctx context.Context, kmssvc kmsiface.KMSAPI, keyID string) (*D
 		return nil, fmt.Errorf("failed to lookup key %s: %w", keyID, err)
 	}
 
+	pkresp, err := kmssvc.GetPublicKeyWithContext(ctx, &kms.GetPublicKeyInput{
+		KeyId: &keyID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch public key for %s: %w", keyID, err)
+	}
+
 	if *ki.KeyMetadata.KeyUsage != kms.KeyUsageTypeEncryptDecrypt {
 		return nil, fmt.Errorf("key usage must be %s, not %s", kms.KeyUsageTypeSignVerify, *ki.KeyMetadata.KeyUsage)
 	}
 
-	pub, err := getPublicKey(ctx, kmssvc, keyID)
+	pub, err := parsePublicKey(pkresp.PublicKey)
 	if err != nil {
 		return nil, err
 	}

--- a/decrypter.go
+++ b/decrypter.go
@@ -33,13 +33,6 @@ type Decrypter struct {
 // NewDecrypter will configure a new decrypter using the given KMS client, bound
 // to the given key.
 func NewDecrypter(ctx context.Context, kmssvc kmsiface.KMSAPI, keyID string) (*Decrypter, error) {
-	ki, err := kmssvc.DescribeKeyWithContext(ctx, &kms.DescribeKeyInput{
-		KeyId: &keyID,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to lookup key %s: %w", keyID, err)
-	}
-
 	pkresp, err := kmssvc.GetPublicKeyWithContext(ctx, &kms.GetPublicKeyInput{
 		KeyId: &keyID,
 	})
@@ -47,8 +40,8 @@ func NewDecrypter(ctx context.Context, kmssvc kmsiface.KMSAPI, keyID string) (*D
 		return nil, fmt.Errorf("failed to fetch public key for %s: %w", keyID, err)
 	}
 
-	if *ki.KeyMetadata.KeyUsage != kms.KeyUsageTypeEncryptDecrypt {
-		return nil, fmt.Errorf("key usage must be %s, not %s", kms.KeyUsageTypeSignVerify, *ki.KeyMetadata.KeyUsage)
+	if *pkresp.KeyUsage != kms.KeyUsageTypeEncryptDecrypt {
+		return nil, fmt.Errorf("key usage must be %s, not %s", kms.KeyUsageTypeSignVerify, *pkresp.KeyUsage)
 	}
 
 	pub, err := parsePublicKey(pkresp.PublicKey)

--- a/kms.go
+++ b/kms.go
@@ -20,7 +20,11 @@ func getPublicKey(ctx context.Context, kmssvc kmsiface.KMSAPI, keyID string) (cr
 		return nil, fmt.Errorf("failed to fetch public key for %s: %w", keyID, err)
 	}
 
-	pubk, err := x509.ParsePKIXPublicKey(pkresp.PublicKey)
+	return parsePublicKey(pkresp.PublicKey)
+}
+
+func parsePublicKey(publicKey []byte) (crypto.PublicKey, error) {
+	pubk, err := x509.ParsePKIXPublicKey(publicKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse public key: %w", err)
 	}

--- a/kms.go
+++ b/kms.go
@@ -1,27 +1,12 @@
 package awskms
 
 import (
-	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
-
-	"github.com/aws/aws-sdk-go/service/kms"
-	"github.com/aws/aws-sdk-go/service/kms/kmsiface"
 )
-
-func getPublicKey(ctx context.Context, kmssvc kmsiface.KMSAPI, keyID string) (crypto.PublicKey, error) {
-	pkresp, err := kmssvc.GetPublicKeyWithContext(ctx, &kms.GetPublicKeyInput{
-		KeyId: &keyID,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch public key for %s: %w", keyID, err)
-	}
-
-	return parsePublicKey(pkresp.PublicKey)
-}
 
 func parsePublicKey(publicKey []byte) (crypto.PublicKey, error) {
 	pubk, err := x509.ParsePKIXPublicKey(publicKey)

--- a/signer.go
+++ b/signer.go
@@ -39,11 +39,18 @@ func NewSigner(ctx context.Context, kmssvc kmsiface.KMSAPI, keyID string) (*Sign
 		return nil, fmt.Errorf("failed to lookup key %s: %w", keyID, err)
 	}
 
+	pkresp, err := kmssvc.GetPublicKeyWithContext(ctx, &kms.GetPublicKeyInput{
+		KeyId: &keyID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch public key for %s: %w", keyID, err)
+	}
+
 	if *ki.KeyMetadata.KeyUsage != kms.KeyUsageTypeSignVerify {
 		return nil, fmt.Errorf("key usage must be %s, not %s", kms.KeyUsageTypeSignVerify, *ki.KeyMetadata.KeyUsage)
 	}
 
-	pub, err := getPublicKey(ctx, kmssvc, keyID)
+	pub, err := parsePublicKey(pkresp.PublicKey)
 	if err != nil {
 		return nil, err
 	}

--- a/signer_test.go
+++ b/signer_test.go
@@ -76,3 +76,16 @@ func TestSignerE2E(t *testing.T) {
 		t.Fatalf("error verifying message with public key: %v", err)
 	}
 }
+
+func TestExtractKeyID(t *testing.T) {
+	arn := "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+
+	keyID, err := extractKeyID(arn)
+	if err != nil {
+		t.Fatalf("error extracting key ID: %v", err)
+	}
+
+	if got, want := keyID, "1234abcd-12ab-34cd-56ef-1234567890ab"; got != want {
+		t.Fatalf("got: %s, want: %s", got, want)
+	}
+}


### PR DESCRIPTION
I was playing around with some other code and realized that [the `GetPublicKey` call](https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html) returns enough response elements to drop the reliance on [the `DescribeKey` call](https://docs.aws.amazon.com/kms/latest/APIReference/API_DescribeKey.html). This will not only reduce the API calls required to initialize the decrypter/signer with 50 % but also make it possible to enforce a more restrictive IAM policy.

The one difference in API response is that the field `KeyId` returns a key ID for the `DescribeKey` call whereas it returns a key ARN for the `GetPublicKey`. I choose to parse it but I would be fine changing the interface to always return the ARN and having callers parse it instead.