### PR TITLE
Replace KeyID with additional info

### DIFF
--- a/kms.go
+++ b/kms.go
@@ -7,16 +7,57 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
+	"strings"
 
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 )
 
 var _ KMSClient = (*kms.Client)(nil)
 
+// KMSClient describes the KMS operations this module requires, this will
+// normally be satisfied by the aws-sdk-go-v2 *kms.Client
 type KMSClient interface {
 	GetPublicKey(context.Context, *kms.GetPublicKeyInput, ...func(*kms.Options)) (*kms.GetPublicKeyOutput, error)
 	Sign(context.Context, *kms.SignInput, ...func(*kms.Options)) (*kms.SignOutput, error)
 	Decrypt(context.Context, *kms.DecryptInput, ...func(*kms.Options)) (*kms.DecryptOutput, error)
+}
+
+// KeyInfo contains information about the underlying KMS key.
+type KeyInfo struct {
+	// ID contains the ID of the key.
+	ID string
+	// ARN contains the AWS Resource Name for the KMS key
+	ARN string
+	// Alias contains the key alias that was used to retrieve the key, if it was
+	// retrieve by an alias. Otherwise, it will be empty. The alias/ prefix is
+	// stripped.
+	Alias string
+}
+
+// parsePubKeyResp loads the public key and the KeyInfo from the response
+func parsePubKeyResp(reqID string, resp *kms.GetPublicKeyOutput) (crypto.PublicKey, KeyInfo, error) {
+	pub, err := parsePublicKey(resp.PublicKey)
+	if err != nil {
+		return nil, KeyInfo{}, err
+	}
+
+	// this KeyId field is always the ARN. Naming in KMS is fun.
+	targetKeyID, err := extractKeyID(*resp.KeyId)
+	if err != nil {
+		return nil, KeyInfo{}, err
+	}
+
+	var alias string
+	if strings.HasPrefix(reqID, "alias/") {
+		alias = strings.TrimPrefix(reqID, "alias/")
+	}
+
+	return pub, KeyInfo{
+		ARN:   *resp.KeyId,
+		ID:    targetKeyID,
+		Alias: alias,
+	}, err
 }
 
 func parsePublicKey(publicKey []byte) (crypto.PublicKey, error) {
@@ -33,4 +74,22 @@ func parsePublicKey(publicKey []byte) (crypto.PublicKey, error) {
 	default:
 		return nil, fmt.Errorf("public key is of unhandled type: %T", pubk)
 	}
+}
+
+func extractKeyID(arn string) (string, error) {
+	parn, err := awsarn.Parse(arn)
+	if err != nil {
+		return "", fmt.Errorf("parsing arn %s: %w", arn, err)
+	}
+	arnSegments := strings.Split(arn, ":")
+	if len(arnSegments) != 6 {
+		return "", fmt.Errorf("unexpected number of ARN segments: %s", arn)
+	}
+
+	targetKeyID := parn.Resource
+	if !strings.HasPrefix(targetKeyID, "key/") {
+		return "", fmt.Errorf("unexpected key ID format: %s", targetKeyID)
+	}
+
+	return strings.TrimPrefix(targetKeyID, "key/"), nil
 }

--- a/kms_test.go
+++ b/kms_test.go
@@ -10,23 +10,28 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 )
 
-type testAliases struct {
-	ECSignVerify      string
-	RSASignVerify     string
-	RSAEncryptDecrypt string
+type testKeys struct {
+	ECSignVerifyAlias      string
+	RSASignVerifyAlias     string
+	RSAEncryptDecryptAlias string
+
+	// these are only wired up for local-kms usage
+	ECSignVerifyARN      string
+	RSASignVerifyARN     string
+	RSAEncryptDecryptARN string
 }
 
-func testKMSClient(t *testing.T) (*kms.Client, testAliases) {
+func testKMSClient(t *testing.T) (*kms.Client, testKeys) {
 	t.Helper()
 
 	if os.Getenv("TEST_KMS") == "" && os.Getenv("TEST_LOCAL_KMS") == "" {
 		t.Skip("TEST_KMS or TEST_LOCAL_KMS not set, skipping")
 	}
 
-	aliases := testAliases{
-		ECSignVerify:      os.Getenv("TEST_KMS_ALIAS_EC_SIGN_VERIFY"),
-		RSASignVerify:     os.Getenv("TEST_KMS_ALIAS_RSA_SIGN_VERIFY"),
-		RSAEncryptDecrypt: os.Getenv("TEST_KMS_ALIAS_RSA_ENCRYPT_DECRYPT"),
+	keys := testKeys{
+		ECSignVerifyAlias:      os.Getenv("TEST_KMS_ALIAS_EC_SIGN_VERIFY"),
+		RSASignVerifyAlias:     os.Getenv("TEST_KMS_ALIAS_RSA_SIGN_VERIFY"),
+		RSAEncryptDecryptAlias: os.Getenv("TEST_KMS_ALIAS_RSA_ENCRYPT_DECRYPT"),
 	}
 
 	kmsOpts := []func(*kms.Options){}
@@ -47,12 +52,29 @@ func testKMSClient(t *testing.T) (*kms.Client, testAliases) {
 		awscfg.Region = "us-east-2"
 		awscfg.Credentials = credentials.NewStaticCredentialsProvider("AKIA11111111", "2222222222222", "")
 
-		aliases.ECSignVerify = "alias/ec_sign_verify"
-		aliases.RSASignVerify = "alias/rsa_sign_verify"
-		aliases.RSAEncryptDecrypt = "alias/rsa_encrypt_decrypt"
+		keys.ECSignVerifyAlias = "alias/ec_sign_verify"
+		keys.RSASignVerifyAlias = "alias/rsa_sign_verify"
+		keys.RSAEncryptDecryptAlias = "alias/rsa_encrypt_decrypt"
+
+		keys.ECSignVerifyARN = "arn:aws:kms:eu-west-2:111122223333:key/3aa0759e-169c-4de4-bb74-38b02b319e9d"
+		keys.RSASignVerifyARN = "arn:aws:kms:eu-west-2:111122223333:key/cd7b6e4a-154a-4fb8-b013-63bb43c48cd8"
+		keys.RSAEncryptDecryptARN = "arn:aws:kms:eu-west-2:111122223333:key/a1d398f5-2b1c-40d5-82f4-bb97696d6975"
 	}
 
 	kmsClient := kms.NewFromConfig(awscfg, kmsOpts...)
 
-	return kmsClient, aliases
+	return kmsClient, keys
+}
+
+func TestExtractKeyID(t *testing.T) {
+	arn := "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+
+	keyID, err := extractKeyID(arn)
+	if err != nil {
+		t.Fatalf("error extracting key ID: %v", err)
+	}
+
+	if got, want := keyID, "1234abcd-12ab-34cd-56ef-1234567890ab"; got != want {
+		t.Fatalf("got: %s, want: %s", got, want)
+	}
 }


### PR DESCRIPTION
The KeyID is useful in some cases (e.g for OIDC keys), but is not the only useful information about the key. Expand this into a KeyInfo type, that includes the ID, the ARN, and the alias if it was loaded that way.

This is added to the Decrypter as well for consistency.